### PR TITLE
Schema check

### DIFF
--- a/MetadataModel.py
+++ b/MetadataModel.py
@@ -209,7 +209,8 @@ class MetadataModel(object):
                     errorMessage = errorMessage[5:1000]
                 
                 if len(e.path) < 2:
-                    errors.append(["", "Manifest with wrong schema provided", "", errorMessage])    
+                    errors.append(["", "Manifest with wrong schema provided", "", errorMessage])
+                    break
                 else:
                     errors.append([errorRow, e.path[1], e.value, errorMessage])    
                 

--- a/MetadataModel.py
+++ b/MetadataModel.py
@@ -202,15 +202,7 @@ class MetadataModel(object):
                 validate(jsonSchema, annotation)
             
              except JsonSchemaException as e:
-                """
-                print(e.message)
-                print(e.name)
-                print(e.path)
-                print(e.definition)
-                print(e.value)
-                print(e.rule)
-                print(e.rule_definition)
-                """
+                
                 errorRow = i + 2
                 errorMessage = e.message[0:1000]
                 if "data." in errorMessage:

--- a/MetadataModel.py
+++ b/MetadataModel.py
@@ -209,7 +209,7 @@ class MetadataModel(object):
                     errorMessage = errorMessage[5:1000]
                 
                 if len(e.path) < 2:
-                    errors.append([errorRow, "Manifest with wrong schema provided", e.value, errorMessage])    
+                    errors.append(["", "Manifest with wrong schema provided", "", errorMessage])    
                 else:
                     errors.append([errorRow, e.path[1], e.value, errorMessage])    
                 

--- a/MetadataModel.py
+++ b/MetadataModel.py
@@ -216,15 +216,11 @@ class MetadataModel(object):
                 if "data." in errorMessage:
                     errorMessage = errorMessage[5:1000]
                 
-                
-                errors.append([errorRow, e.path[1], e.value, errorMessage])    
-                
-                """
                 if len(e.path) < 2:
                     errors.append([errorRow, "Manifest with wrong schema provided", e.value, errorMessage])    
                 else:
                     errors.append([errorRow, e.path[1], e.value, errorMessage])    
-                """
+                
          return errors
 
      

--- a/schema_generator.py
+++ b/schema_generator.py
@@ -271,11 +271,12 @@ def get_node_definition(se:SchemaExplorer, node_display_name:str) -> str:
           display_name: node display name
         
          Returns: a node definition 
-         Raises: 
-            ValueError: TODO: node label not found in metadata model.
         """
         # get node label
         node_label = get_node_label(se, node_display_name)
+
+        if not node_label:
+            return ""
 
         # get node definition from schema
         schema_graph = se.get_nx_schema()


### PR DESCRIPTION
Reintroduced code that returns validation error when a csv with the wrong schema is uploaded; the returned error array in this case has format

[["", "Manifest with wrong schema provided", "", errorMessage]]
