### PR TITLE
Validation lists all errors

### DIFF
--- a/MetadataModel.py
+++ b/MetadataModel.py
@@ -208,7 +208,7 @@ class MetadataModel(object):
                  errorRow = i + 2
                  errorCol = error.path[-1] if len(error.path) > 0 else "Wrong schema" 
                  errorMsg = error.message[0:500]
-                 errorVal = error.instance
+                 errorVal = error.instance if len(error.path) > 0 else "Wrong schema"
 
                  errors.append([errorRow, errorCol, errorMsg, errorVal])
                 

--- a/config.py
+++ b/config.py
@@ -5,8 +5,8 @@ Stores config variables to be used in other modules
 storage = {
     "Synapse":{
       #synapse ID of fileview containing administrative storage metadata; 
-      "masterFileview":"syn21893840",
-      #"masterFileview":"syn20446927",
+      #"masterFileview":"syn21893840",
+      "masterFileview":"syn20446927",
       # default manifest name 
       "manifestFilename":"synapse_storage_manifest.csv"
     }
@@ -22,7 +22,7 @@ style = {
         "googleManifest":{
             #required columns/cells background color
             "reqBgColor":{
-                        'red': 235.0/255,
+                        'red': 231.0/255,
                         'green': 248.0/255,
                         'blue': 250.0/255
             },


### PR DESCRIPTION
Addresses #15 and handles the backend for https://github.com/sage-bionetworks/htan_data_curator/issues/11.

The error list is returned in the same format as before. There could be multiple errors for each row (since errors are now included for all columns with erroneous values); previously there was one erroneous value per row. However, no changes should be needed to handle the error display, @xdoan can verify.

Note that if the schema is wrong, the returned error column and error value in the error list are "Wrong schema".