### PR TITLE
synapse client package upgrade

### DIFF
--- a/ingresspipe/synapse/store.py
+++ b/ingresspipe/synapse/store.py
@@ -413,7 +413,17 @@ class SynapseStorage(object):
 
                 metadataSyn[keySyn] = v
 
-            self.syn.setAnnotations(entityId, metadataSyn)
+            # set annotation(s) for the various objects/items in a dataset on Synapse
+            annos = self.syn.get_annotations(entityId)
+
+            for anno_k, anno_v in annos.items():
+                if anno_k in metadataSyn:
+                    annos[anno_k] = metadataSyn[anno_k]
+
+            print(annos)
+
+            self.syn.set_annotations(annos)
+            # self.syn.set_annotations(metadataSyn) -- deprecated code
 
         # create/update a table corresponding to this dataset in this dataset's parent project
 

--- a/ingresspipe/synapse/store.py
+++ b/ingresspipe/synapse/store.py
@@ -420,8 +420,6 @@ class SynapseStorage(object):
                 if anno_k in metadataSyn:
                     annos[anno_k] = metadataSyn[anno_k]
 
-            print(annos)
-
             self.syn.set_annotations(annos)
             # self.syn.set_annotations(metadataSyn) -- deprecated code
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-networkx==2.2
+networkx==2.4
 rdflib==4.2.2
 tabletext==0.1
 graphviz==0.8.4
@@ -11,7 +11,7 @@ google-auth-oauthlib==0.4.0
 pandas==0.23.4
 pygsheets==2.0.1
 inflection==0.3.1
-synapseclient==1.9.2
+synapseclient==2.1.0
 setuptools==41.2.0
 pyyaml==5.3.1
 matplotlib==3.2.2


### PR DESCRIPTION
Upgrade `synapseclient==2.1.0` rather than using _version_ `1.9.2`.

Change made: potentially breaking/deprecating change in `getAnnotations()` and `setAnnotations()` methods. Latest version of the client uses `get_annotations()` and `set_annotations()` instead.