### PR TITLE
propagating changes made to load_schema_into_networkx()

### DIFF
--- a/ingresspipe/schemas/explorer.py
+++ b/ingresspipe/schemas/explorer.py
@@ -432,9 +432,9 @@ class SchemaExplorer():
         multi_digraph = self.schema_nx   
 
         digraph = nx.DiGraph()
-        for edge in multi_digraph.edges(data = True, keys = True):
-            if edge[3]["relationship"] == edge_type:
-                digraph.add_edge(edge[0], edge[1])
+        for (u, v, key, c) in multi_digraph.edges(data=True, keys=True):
+            if key == edge_type:
+                digraph.add_edge(u, v)
 
         #print(nx.find_cycle(digraph, orientation = "ignore"))
 

--- a/ingresspipe/schemas/generator.py
+++ b/ingresspipe/schemas/generator.py
@@ -75,8 +75,8 @@ class SchemaGenerator(object):
 
         mm_graph = self.se.get_nx_schema()
 
-        for u, v, properties in mm_graph.out_edges(node, data=True):
-            if properties["relationship"] == relationship:
+        for (u, v, key, c) in mm_graph.out_edges(node, data=True, keys=True):
+            if key == relationship:
                 edges.append((u, v))
 
         return sorted(edges)
@@ -98,8 +98,8 @@ class SchemaGenerator(object):
         
         mm_graph = self.se.get_nx_schema()
 
-        for u, v, properties in mm_graph.out_edges(node, data=True):
-            if properties["relationship"] == relationship:
+        for (u, v, key, c) in mm_graph.out_edges(node, data=True, keys=True):
+            if key == relationship:
                 nodes.add(v)
 
         return sorted(list(nodes))
@@ -140,8 +140,8 @@ class SchemaGenerator(object):
 
         # prune the descendants subgraph so as to include only those edges that match the relationship type
         rel_edges = []
-        for u, v, properties in descendants_subgraph.edges(data=True):
-            if properties["relationship"] == relationship:
+        for (u, v, key, c) in descendants_subgraph.edges(data=True, keys=True):
+            if key == relationship:
                 rel_edges.append((u, v))
 
         relationship_subgraph = nx.DiGraph()


### PR DESCRIPTION
This PR addresses the following issue: Since we made modifications to `load_schema_into_networkx()` method in `schema_utils.py` file/module to use `key` to label an edge instead of a keyword dictionary, we need to make sure `"relationship"` (former name of the edge label), now uses `key`.