### PR TITLE
added examples directory

### DIFF
--- a/examples/csv_to_schemaorg.py
+++ b/examples/csv_to_schemaorg.py
@@ -1,0 +1,37 @@
+import os
+import json
+
+import pandas as pd
+
+from ingresspipe.schemas.explorer import SchemaExplorer
+
+from ingresspipe.utils.csv_utils import create_schema_classes
+from ingresspipe.utils.config_utils import load_yaml
+
+from definitions import CONFIG_PATH, DATA_PATH
+
+config_data = load_yaml(CONFIG_PATH)
+
+# path to base schema
+base_schema_path = os.path.join(DATA_PATH, '', config_data["model"]["biothings"]["location"])
+
+# schema name (used to name schema json-ld file as well)
+output_schema_name = "HTAN"
+
+# schema extension definition csv files
+schema_extensions_csv = [
+                        os.path.join(DATA_PATH, '', 'csv/HTAN.csv')
+                        ]
+
+# instantiate schema explorer
+base_se = SchemaExplorer()
+
+# load base schema (BioThings)
+base_se.load_schema(base_schema_path)
+
+for schema_extension_csv in schema_extensions_csv:
+    schema_extension = pd.read_csv(schema_extension_csv)
+    base_se = create_schema_classes(schema_extension, base_se)
+
+# saving updated schema.org schema
+base_se.export_schema(os.path.join(os.path.dirname(base_schema_path), output_schema_name + ".jsonld"))

--- a/examples/manifest_generator.py
+++ b/examples/manifest_generator.py
@@ -1,0 +1,26 @@
+import synapseclient
+import os
+
+from ingresspipe.manifest.generator import ManifestGenerator
+
+from ingresspipe.utils.google_api_utils import download_creds_file
+from ingresspipe.utils.config_utils import load_yaml
+
+from definitions import CONFIG_PATH, DATA_PATH
+
+config_data = load_yaml(CONFIG_PATH)
+
+PATH_TO_JSONLD = os.path.join(DATA_PATH, config_data["model"]["input"]["location"])
+
+# create an instance of ManifestGenerator class
+TEST_NODE = "FollowUp"
+manifest_generator = ManifestGenerator(title="FollowUp Manifest", path_to_json_ld=PATH_TO_JSONLD, root=TEST_NODE)
+
+# make sure the 'credentials.json' file is downloaded and is present in the right path/location
+try:
+    download_creds_file()
+except synapseclient.core.exceptions.SynapseHTTPError:
+    print("Make sure the credentials set in the config file are correct.")
+
+# get manifest (csv) url
+print(manifest_generator.get_manifest())

--- a/examples/metadata_model.py
+++ b/examples/metadata_model.py
@@ -1,0 +1,121 @@
+import json
+import os
+import sys
+
+from ingresspipe.models.metadata import MetadataModel
+
+from ingresspipe.utils.config_utils import load_yaml
+from definitions import ROOT_DIR, CONFIG_PATH, CREDS_PATH, DATA_PATH
+
+# load config data from yaml file into config_data dict
+config_data = load_yaml(CONFIG_PATH)
+
+if config_data is None:
+    sys.exit("Your config file may be empty.")
+
+# path to the JSON-LD schema that is stored "locally" in the app directory
+MM_LOC = os.path.join(DATA_PATH, config_data["model"]["input"]["location"])
+MM_TYPE = config_data["model"]["input"]["file_type"]
+
+# create instance of MetadataModel class
+metadata_model_htan = MetadataModel(MM_LOC, MM_TYPE)
+print("*****************************************************")
+
+# TEST_COMP used for testing methods in 'metadata.py'
+TEST_COMP = "FollowUp"
+
+# testing manifest generation - manifest is generated based on a JSON schema parsed from schema.org schema, which generates a google spreadsheet.
+# To generate the sheet, the backend requires Google API credentials in a file credentials.json stored locally in the same directory as this file
+# this credentials file is also stored on Synapse and can be retrieved given sufficient permissions to the Synapse project
+
+# Google API credentials file stored on Synapse
+API_CREDS = config_data["synapse"]["api_creds"]
+
+# try downloading 'credentials.json' file (if not present already)
+if not os.path.exists(CREDS_PATH):
+
+    print("Retrieving Google API credentials from Synapse..")
+    import synapseclient
+
+    syn = synapseclient.Synapse()
+    syn.login()
+    syn.get(API_CREDS, downloadLocation = ROOT_DIR)
+    print("Stored Google API credentials.")
+
+print("Google API credentials successfully located..")
+
+print("*****************************************************")
+
+# testing manifest generation from a given root node without optionally provided JSON schema
+print("Testing manifest generation based on a provided schema.org schema..")
+manifest_url = metadata_model_htan.getModelManifest(title="Test_" + TEST_COMP, rootNode=TEST_COMP, filenames=["1.txt", "2.txt", "3.txt"])
+print(manifest_url)
+
+print("*****************************************************")
+
+# testing manifest generation with optionally provided JSON validation schema
+print("Testing manifest generation based on an additionally provided JSON schema..")
+HTAPP_VALIDATION_SCHEMA = os.path.join(DATA_PATH, config_data["model"]["demo"]["validation_file_location"])
+
+with open(HTAPP_VALIDATION_SCHEMA, "r") as f:
+    json_schema = json.load(f)
+
+HTAPP_SCHEMA = os.path.join(DATA_PATH, config_data["model"]["demo"]["location"])
+HTAPP_SCHEMA_TYPE = config_data["model"]["demo"]["file_type"]
+
+metadata_model_htapp = MetadataModel(HTAPP_SCHEMA, HTAPP_SCHEMA_TYPE)
+manifest_url = metadata_model_htapp.getModelManifest(title="Example Manifest", rootNode="", jsonSchema=json_schema)
+print(manifest_url)
+
+print("*****************************************************")
+
+# use JSON schema object to validate the integrity of annotations in manifest file (track annotation errors)
+# without optionally/additionally provided JSON schema
+print("Testing metadata model-based validation..")
+
+MANIFEST_PATH = os.path.join(DATA_PATH, config_data["model"]["demo"]["valid_manifest"])
+print("Testing validation with jsonSchema generation from schema.org schema..")
+annotation_errors = metadata_model_htan.validateModelManifest(MANIFEST_PATH, TEST_COMP)
+print(annotation_errors)
+
+print("*****************************************************")
+
+# use JSON schema object to validate the integrity of annotations in manifest file (track annotation errors)
+# with additionally provided JSON schema
+print("Testing validation with provided JSON schema..")
+annotation_errors = metadata_model_htapp.validateModelManifest(MANIFEST_PATH, TEST_COMP, json_schema)
+print(annotation_errors)
+
+print("*****************************************************")
+
+# populate a manifest with content from an already existing/filled out manifest
+print("Testing metadata model-based manifest population..")
+pre_populated_manifest_url = metadata_model_htan.populateModelManifest("Test_" + TEST_COMP, MANIFEST_PATH, TEST_COMP)
+print(pre_populated_manifest_url)
+
+print("*****************************************************")
+
+# get all the nodes that are dependent on a given node based on a specific relationship type
+print("Testing metadata model-based object dependency generation..")
+print("Generating dependency graph and ordering dependencies..")
+dependencies = metadata_model_htan.getOrderedModelNodes(TEST_COMP, "requiresDependency")
+print(dependencies)
+
+with open(TEST_COMP + "_dependencies.json", "w") as f:
+    json.dump(dependencies, f, indent = 3)
+
+print("Dependencies stored in: " + TEST_COMP + "_dependencies.json")
+
+print("*****************************************************")
+
+# get all nodes that are dependent on a given component
+print("Testing metadata model-based component dependency generation..")
+print("Generating dependency graph and ordering dependencies..")
+
+dependencies = metadata_model_htan.getOrderedModelNodes(TEST_COMP, "requiresComponent")
+print(dependencies)
+
+with open(TEST_COMP + "component_dependencies.json", "w") as f:
+    json.dump(dependencies, f, indent = 3)
+
+print("component dependencies stored: " + TEST_COMP + "component_dependencies.json")

--- a/examples/schema_explorer.py
+++ b/examples/schema_explorer.py
@@ -1,0 +1,120 @@
+from ingresspipe.schemas.explorer import SchemaExplorer
+import networkx as nx
+import os
+from networkx.drawing.nx_agraph import graphviz_layout, to_agraph
+from graphviz import Digraph, Source
+
+from definitions import DATA_PATH, CONFIG_PATH
+from ingresspipe.utils.config_utils import load_yaml
+
+config_data = load_yaml(CONFIG_PATH)
+
+PATH_TO_JSONLD = os.path.join(DATA_PATH, config_data["model"]["input"]["location"])
+
+# create an object of the SchemaExplorer() class
+schema_explorer = SchemaExplorer()
+
+if isinstance(schema_explorer, SchemaExplorer):
+    print("'schema_explorer' - an object of the SchemaExplorer class has been created successfully.")
+else:
+    print("object of class SchemaExplorer could not be created.")
+
+# by default schema exploerer loads the biothings schema
+# to explicitly load a different data model/json-ld schema use load_schema()
+schema_explorer.load_schema(PATH_TO_JSONLD)
+print("schema at {} has been loaded.".format(PATH_TO_JSONLD))
+
+# get the networkx graph generated from the json-ld
+nx_graph = schema_explorer.get_nx_schema()
+
+if isinstance(nx_graph, nx.MultiDiGraph):
+    print("'nx_graph' - object of class MultiDiGraph has been retreived successfully.")
+else:
+    print("object of class SchemaExplorer could not be retreived.")
+
+# check if a particular class is in the current HTAN JSON-LD schema (or any schema that has been loaded)
+TEST_CLASS = 'Sequencing'
+is_or_not = schema_explorer.is_class_in_schema(TEST_CLASS)
+
+if is_or_not == True:
+    print("The class {} is present in the schema.".format(TEST_CLASS))
+else:
+    print("The class {} is not present in the schema.".format(TEST_CLASS))
+
+# graph visualization of the entire HTAN JSON-LD schema
+gv_digraph = schema_explorer.full_schema_graph()
+
+# since the graph is very big, we will generate an svg viz. of it
+gv_digraph.format = 'svg'
+gv_digraph.render(os.path.join(DATA_PATH, '', 'viz/HTAN-GV'), view=True)
+print("The svg visualization of the entire schema has been rendered.")
+
+# graph visualization of a sub-schema
+seq_subgraph = schema_explorer.sub_schema_graph(TEST_CLASS, "up")
+
+seq_subgraph.format = 'svg'
+seq_subgraph.render('SUB-GV', view=True)
+print("The svg visualization of the sub-schema with {} as the source node has been rendered.".format(TEST_CLASS))
+
+# returns list of successors of a node
+seq_children = schema_explorer.find_children_classes(TEST_CLASS)
+print("These are the children of {} class: {}".format(TEST_CLASS, seq_children))
+
+# returns list of parents of a node
+seq_parents = schema_explorer.find_parent_classes(TEST_CLASS)
+print("These are the parents of {} class: {}".format(TEST_CLASS, seq_parents))
+
+# find the properties that are associated with a class
+PROP_CLASS = 'BiologicalEntity'
+class_props = schema_explorer.find_class_specific_properties(PROP_CLASS)
+print("The properties associated with class {} are: {}".format(PROP_CLASS, class_props))
+
+# find the schema classes that inherit from a given class
+inh_classes = schema_explorer.find_child_classes("Assay")
+print("classes that inherit from class 'Assay' are: {}".format(inh_classes))
+
+# get all details about a specific class in the schema
+class_details = schema_explorer.explore_class(TEST_CLASS)
+print("information/details about class {} : {} ".format(TEST_CLASS, class_details))
+
+# get all details about a specific property in the schema
+TEST_PROP = 'increasesActivityOf'
+prop_details = schema_explorer.explore_property(TEST_PROP)
+print("information/details about property {} : {}".format(TEST_PROP, prop_details))
+
+# get name/label of the property associated with a given class' display name
+prop_label = schema_explorer.get_property_label_from_display_name("Basic Statistics")
+print("label of the property associated with 'Basic Statistics': {}".format(prop_label))
+
+# get name/label of the class associated with a given class' display name
+class_label = schema_explorer.get_property_label_from_display_name("Basic Statistics")
+print("label of the class associated with 'Basic Statistics': {}".format(class_label))
+
+# generate template of class in schema
+class_temp = schema_explorer.generate_class_template()
+print("generic template of a class in the schema/data model: {}".format(class_temp))
+
+# modified TEST_CLASS ("Sequencing") based on the above generated template
+class_mod = {
+                "@id": "bts:Sequencing",
+                "@type": "rdfs:Class",
+                "rdfs:comment": "Modified Test: Module for next generation sequencing assays",
+                "rdfs:label": "Sequencing",
+                "rdfs:subClassOf": [
+                    {
+                        "@id": "bts:Assay"
+                    }
+                ],
+                "schema:isPartOf": {
+                    "@id": "http://schema.biothings.io"
+                },
+                "sms:displayName": "Sequencing",
+                "sms:required": "sms:false"
+            }
+
+# make edits to TEST_CLASS based on the above template and pass it to edit_class() 
+schema_explorer.edit_class(class_info=class_mod)
+
+# verify that the comment associated with TEST_CLASS has indeed been changed
+class_details = schema_explorer.explore_class(TEST_CLASS)
+print("Modified {} details : {}".format(TEST_CLASS, class_details))

--- a/examples/schema_generator.py
+++ b/examples/schema_generator.py
@@ -1,0 +1,83 @@
+import os
+from ingresspipe.schemas.generator import SchemaGenerator
+
+from definitions import DATA_PATH, CONFIG_PATH
+from ingresspipe.utils.config_utils import load_yaml
+
+config_data = load_yaml(CONFIG_PATH)
+
+PATH_TO_JSONLD = os.path.join(DATA_PATH, config_data["model"]["input"]["location"])
+
+# create an object of SchemaGenerator() class
+schema_generator = SchemaGenerator(PATH_TO_JSONLD)
+
+if isinstance(schema_generator, SchemaGenerator):
+    print("'schema_generator' - an object of the SchemaGenerator class has been created successfully.")
+else:
+    print("object of class SchemaGenerator could not be created.")
+
+# get list of the out-edges from a node based on a specific relationship
+TEST_NODE = "Sequencing"
+TEST_REL = "parentOf"
+
+out_edges = schema_generator.get_edges_by_relationship(TEST_NODE, TEST_REL)
+
+if out_edges:
+    print("The out-edges from class {}, based on {} relationship are: {}".format(TEST_NODE, TEST_REL, out_edges))
+else:
+    print("The class does not have any out-edges.")
+
+# get list of nodes that are adjacent to specified node, based on a given relationship
+adj_nodes = schema_generator.get_adjacent_nodes_by_relationship(TEST_NODE, TEST_REL)
+
+if adj_nodes:
+    print("The node(s) adjacent to {}, based on {} relationship are: {}".format(TEST_NODE, TEST_REL, adj_nodes))
+else:
+    print("The class does not have any adjacent nodes.")
+
+# get list of descendants (nodes) based on a specific type of relationship
+desc_nodes = schema_generator.get_descendants_by_edge_type(TEST_NODE, TEST_REL)
+
+if desc_nodes:
+    print("The descendant(s) from {} are: {}".format(TEST_NODE, desc_nodes))
+else:
+    print("The class does not have descendants.")
+
+# get all components associated with a given component
+TEST_COMP = "Patient"
+req_comps = schema_generator.get_component_requirements(TEST_COMP)
+
+if req_comps:
+    print("The component(s) that are associated with a given component: {}".format(req_comps))
+else:
+    print("There are no components associated with {}".format(TEST_COMP))
+
+# get immediate dependencies that are related to a given node
+node_deps = schema_generator.get_node_dependencies(TEST_COMP)
+
+if node_deps:
+    print("The immediate dependencies of {} are: {}".format(TEST_COMP, node_deps))
+else:
+    print("The node has no immediate dependencies.")
+
+# get label for a given node
+try:
+    node_label = schema_generator.get_node_label(TEST_NODE)
+
+    print("The label name for the node {} is: {}".format(TEST_NODE, node_label))
+except KeyError:
+    print("Please try a valid node name.")
+
+# get node definition/comment
+try:
+    node_def = schema_generator.get_node_definition(TEST_NODE)
+
+    print("The node definition for node {} is: {}".format(TEST_NODE, node_def))
+except KeyError:
+    print("Please try a valid node name.")
+
+# gather dependencies and value-constraints for a particular node
+json_schema = schema_generator.get_json_schema_requirements(TEST_COMP, "Patient-Schema")
+
+print("The JSON schema based on {} as source node is:".format(TEST_COMP))
+print(json_schema)

--- a/examples/synapse_store.py
+++ b/examples/synapse_store.py
@@ -1,0 +1,59 @@
+import synapseclient
+import pandas as pd
+import os
+
+from ingresspipe.synapse.store import SynapseStorage
+
+from ingresspipe.utils.config_utils import load_yaml
+
+from definitions import ROOT_DIR, CONFIG_PATH, DATA_PATH
+
+config_data = load_yaml(CONFIG_PATH)
+
+PATH_TO_SYN_CONF = os.path.join(ROOT_DIR, '.synapseConfig')
+
+# create an instance of synapseclient.Synapse() and login
+syn = synapseclient.Synapse(configPath=PATH_TO_SYN_CONF)
+
+try:
+    syn.login()
+except synapseclient.core.exceptions.SynapseNoCredentialsError:
+    print("Please make sure the 'username' and 'password'/'api_key' values have been filled out in .synapseConfig.")
+except synapseclient.core.exceptions.SynapseAuthenticationError:
+    print("Please make sure the credentials in the .synapseConfig file are correct.")
+
+syn_store = SynapseStorage(syn=syn)
+
+# testing the retrieval of list of projects (associated with current user) from synapse
+projects_list = syn_store.getStorageProjects()
+print("Testing retrieval of project list from Synapse...")
+# create pandas df from the list of projects to make results more presentable
+projects_df = pd.DataFrame(projects_list, columns=["Synapse ID", "Project Name"])
+print(projects_df)
+
+# testing the retrieval of list of datasets (associated with given project) from Synapse
+# synapse ID for the "HTAN CenterA" project
+datasets_list = syn_store.getStorageDatasetsInProject(projectId="syn20977135")
+print("Testing retrieval of dataset list within a given storage project from Synapse...")
+datasets_df = pd.DataFrame(datasets_list, columns=["Synapse ID", "Dataset Name"])
+print(datasets_df)
+
+# testing the retrieval of list of files (associated with given dataset) from Synapse
+# synapse ID of the "HTAN_CenterA_BulkRNAseq_AlignmentDataset_1" dataset
+files_list = syn_store.getFilesInStorageDataset(datasetId="syn22125525")
+print("Testing retrieval of file list within a given storage dataset from Synapse")
+files_df = pd.DataFrame(files_list, columns=["Synapse ID", "File Name"])
+print(files_df)
+
+# testing the association of entities with annotation(s) from manifest
+# synapse ID of "HTAN_CenterA_FamilyHistory" dataset and associating with it a validated manifest
+MANIFEST_LOC = os.path.join(DATA_PATH, '', config_data["synapse"]["manifest_filename"])
+print("Testing association of entities with annotation from manifest...")
+manifest_syn_id = syn_store.associateMetadataWithFiles(MANIFEST_LOC, "syn21984120")
+print(manifest_syn_id)
+
+# testing the successful retreival of all manifests associated with a project, accessible by the current user
+print("Testing retreival of all manifests associated with projects accessible by user...")
+manifests_list = syn_store.getAllManifests()
+manifests_df = pd.DataFrame(manifests_list)
+print(manifests_df)


### PR DESCRIPTION
(_Trivial_) PR: Added an `examples/` directory outside the source folder (`ingresspipe/` for now, soon to be `schematic/`) consolidating all the _examples_, to make the _examples_ folder more intuitive/readable, and allow users to run the examples more easily (small paths).